### PR TITLE
Add an attend button for nyc

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,11 @@ const Home: NextPage = () => {
             <p className="italic">Attend (Waterloo)</p>
           </button>
         </Link>
+        <Link href="https://lu.ma/socratica-nyc">
+          <button className="m-10 pr-5 md:pr-10 pl-5 md:pl-10 no-underline">
+            <p className="italic">Attend (NYC)</p>
+          </button>
+        </Link>
         <Link href="https://airtable.com/shrPqKZdL5aLqGeul">
           <button className="m-10 pr-5 md:pr-10 pl-5 md:pl-10 no-underline">
             <p className="italic">Start a chapter</p>


### PR DESCRIPTION
We are hosting our first Socratica in NYC this weekend! Wanted to add a button to attend the NYC one on our landing page. 

If we prefer to keep this page for Waterloo only, we could also
- Make the NYC button smaller
- Use another page (socrati.ca/nyc) 


<img width="1728" alt="image" src="https://user-images.githubusercontent.com/29922764/214373399-3c06ce1e-ce41-45c0-8f2f-511664e4db88.png">
